### PR TITLE
Requirements and traps.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,8 +3,13 @@ numpy==1.14.0
 aiofiles
 # aiomultiprocess
 # aiosqlite
-# asyncpg
-# dataclasses
 # cached_property
 uvloop==0.9.1
 aiohttp==3.2.1
+# Someone forgot to add this in.
+asyncpg
+# Music cog requirements
+opuslib
+dataclasses
+PyNaCl
+youtube_dl

--- a/sebi_machine_launcher.sh
+++ b/sebi_machine_launcher.sh
@@ -1,6 +1,13 @@
 #!/bin/bash
 
-until python -m src; do
-	echo "Sebi-Machine shutdown with error: $?. Restarting..." >&2
-	sleep 1
+# 20th June 2018
+# Esp: added a trap here, as it otherwise attempts to restart when given
+# the interrupt signal. This is really annoying over SSH when I have
+# a 1-second lag anyway.
+trap "echo 'Received interrupt. Exiting.'; exit 0" SIGINT
+until python -m src; do 
+    # Added colouring to ensure the date of shutdown and the exit code stands
+    # out from the other clutter in the traceback that might have been output.
+    echo -e "\e[0;31m[$(date --utc)]\e[0m Sebi-Machine shutdown with error \e[0;31m$?\e[0m. Restarting..." >&2
+    sleep 1
 done


### PR DESCRIPTION
Requirements file was missing five requirements. This might be useful to
have fixed, so I sorted that out.
    - opuslib
    - youtube_dl
    - asyncpg
    - PyNaCl
    - dataclasses

Made the sebi_machine_launcher.sh executable only under the current
owner.

Added a SIGINT trap to sebi_machine_launcher.sh. You are only restarting
while the bot returns a non-truthy exit code (i.e. non zero). SIGINT,
which triggers the Python KeyboardInterrupt builtin exception being
raised will, if unhandled, result in a non-zero exit code. Thus, if you
provide a keyboard interrupt, you will just have the bot instantly
respawn. This is fine until you have a one second lag over SSH. Then my
wrist starts to hurt from spamming CTRL-C so many times until the bot
process dies.